### PR TITLE
Fix: Update CHOSEN_MODEL_NAME to models/gemini-1.5-flash-latest

### DIFF
--- a/chatbot/chatbot/integrations/gemini_client.py
+++ b/chatbot/chatbot/integrations/gemini_client.py
@@ -16,7 +16,7 @@ else:
         print("WARNING: .env file not found at project root or CWD. API key may not be available.")
 
 GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')
-CHOSEN_MODEL_NAME = 'gemini-pro'  # Default model, will be checked against available list
+CHOSEN_MODEL_NAME = 'models/gemini-1.5-flash-latest'  # Default model, will be checked against available list
 model_instance = None
 
 if not GEMINI_API_KEY:


### PR DESCRIPTION
I've updated chatbot/chatbot/integrations/gemini_client.py to use 'models/gemini-1.5-flash-latest' as the CHOSEN_MODEL_NAME based on the list of available models for your API key.

This should resolve the 'model not found' errors and allow successful interaction with the Gemini API.