### PR TITLE
Fix: Correct conversation display in web interface

### DIFF
--- a/chatbot/chatbot/web/app.py
+++ b/chatbot/chatbot/web/app.py
@@ -31,7 +31,8 @@ def chat():
         print(f"DEBUG: app.py - Calling get_response...")
         bot_response = get_response(user_message)
         print(f"DEBUG: app.py - Received bot_response: {bot_response}")
-        conversation.append({'user': user_message, 'bot': bot_response})
+        conversation.append({'sender': 'User', 'text': user_message})
+        conversation.append({'sender': 'Bot', 'text': bot_response})
     # Ensure the template is looked for in the correct relative path
     return render_template('index.html', conversation=list(conversation))
 

--- a/chatbot/chatbot/web/templates/index.html
+++ b/chatbot/chatbot/web/templates/index.html
@@ -27,19 +27,15 @@
         </div>
         <div class="chat-box" id="chatBox">
             {% for chat_item in conversation %}
-                {% if chat_item.user %}
-                    <div class="message user">
-                        <div class="bubble">
-                            <strong>You:</strong> {{ chat_item.user }}
-                        </div>
+                <div class="message {{ 'user' if chat_item.sender == 'User' else 'bot' }}">
+                    <div class="bubble">
+                        {% if chat_item.sender == 'User' %}
+                            <strong>You:</strong> {{ chat_item.text }}
+                        {% elif chat_item.sender == 'Bot' %}
+                            <strong>Bot:</strong> {{ chat_item.text }}
+                        {% endif %}
                     </div>
-                {% elif chat_item.bot %}
-                     <div class="message bot">
-                        <div class="bubble">
-                            <strong>Bot:</strong> {{ chat_item.bot }}
-                        </div>
-                    </div>
-                {% endif %}
+                </div>
             {% endfor %}
         </div>
         <form class="input-area" method="POST" action="/">


### PR DESCRIPTION
Updated chatbot/chatbot/web/app.py to store conversation turns as separate items with 'sender' and 'text' keys.

Updated chatbot/chatbot/web/templates/index.html to correctly render these conversation items, ensuring that both your messages and my responses are displayed in the chatbox.