### PR TITLE
Feat: Add basic admin web interface structure

### DIFF
--- a/chatbot/chatbot/web/admin_views.py
+++ b/chatbot/chatbot/web/admin_views.py
@@ -1,0 +1,85 @@
+import os
+import functools
+from flask import Blueprint, render_template, request, redirect, url_for, session, flash
+from dotenv import load_dotenv
+
+# Load environment variables to get admin credentials
+# This script is in /app/chatbot/chatbot/web/admin_views.py
+# .env is in /app/.env (project root)
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+dotenv_path = os.path.join(project_root, '.env')
+
+if os.path.exists(dotenv_path):
+    load_dotenv(dotenv_path=dotenv_path)
+    # print(f"DEBUG (admin_views): .env loaded from {dotenv_path}")
+else:
+    if load_dotenv(): # Fallback (e.g. if CWD is project root)
+        # print("DEBUG (admin_views): .env loaded via default dotenv search.")
+        pass
+    else:
+        print("WARNING (admin_views): .env file not found. Admin credentials may be missing.")
+
+ADMIN_USERNAME = os.getenv('ADMIN_USERNAME', 'admin') # Default if not set
+ADMIN_PASSWORD = os.getenv('ADMIN_PASSWORD', 'password') # Default if not set
+if ADMIN_USERNAME == 'admin' and ADMIN_PASSWORD == 'password':
+    print("WARNING (admin_views): Using default admin credentials. Set ADMIN_USERNAME and ADMIN_PASSWORD in .env for security.")
+
+
+# The template_folder is relative to the Blueprint's location (admin_views.py)
+# However, Flask typically resolves 'templates/admin' from the app's main template folder (chatbot/web/templates)
+# For clarity and explicit control, let's use an absolute path or ensure app structure.
+# Given blueprint is in 'web', and templates are in 'web/templates/admin', this should work.
+# The 'admin/' prefix in render_template calls refers to subdirectories within the app's main template folder.
+admin_bp = Blueprint('admin', __name__, url_prefix='/admin', template_folder='admin') # Flask will look for templates in web/admin/templates if this was the root
+                                                                                    # Or web/templates/admin (if app's template_folder is 'templates')
+
+def login_required(view):
+    """View decorator that redirects anonymous users to the login page."""
+    @functools.wraps(view)
+    def wrapped_view(**kwargs):
+        if 'admin_logged_in' not in session:
+            return redirect(url_for('admin.login', next=request.url))
+        return view(**kwargs)
+    return wrapped_view
+
+@admin_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        if username == ADMIN_USERNAME and password == ADMIN_PASSWORD:
+            session['admin_logged_in'] = True
+            session.permanent = True
+            flash('Login successful!', 'success')
+            next_url = request.args.get('next')
+            return redirect(next_url or url_for('admin.dashboard'))
+        else:
+            flash('Invalid username or password.', 'danger')
+    if 'admin_logged_in' in session: # If already logged in, redirect to dashboard
+        return redirect(url_for('admin.dashboard'))
+    # For render_template, Flask searches in app's template_folder + blueprint's template_folder_subpath
+    # So, 'admin/admin_login.html' means it looks for <app_template_folder>/admin/admin_login.html
+    return render_template('admin/admin_login.html', title='Admin Login')
+
+@admin_bp.route('/logout')
+@login_required
+def logout():
+    session.pop('admin_logged_in', None)
+    flash('You have been logged out.', 'info')
+    return redirect(url_for('admin.login'))
+
+@admin_bp.route('/')
+@admin_bp.route('/dashboard')
+@login_required
+def dashboard():
+    return render_template('admin/admin_dashboard.html', title='Admin Dashboard')
+
+@admin_bp.route('/rules')
+@login_required
+def manage_rules():
+    return render_template('admin/admin_manage_rules.html', title='Manage Rules')
+
+@admin_bp.route('/appearance')
+@login_required
+def manage_appearance():
+    return render_template('admin/admin_manage_appearance.html', title='Manage Appearance')

--- a/chatbot/chatbot/web/app.py
+++ b/chatbot/chatbot/web/app.py
@@ -1,10 +1,14 @@
 import sys
-import os
+import os # Ensure os is imported for app.secret_key
 from flask import Flask, render_template, request
+# Blueprint import should be after Flask, and before it's used.
+# Assuming admin_views.py is in the same directory (chatbot/web) as app.py for this import style.
+# The PROJECT_ROOT path adjustment should make 'chatbot.web' findable.
+from chatbot.web.admin_views import admin_bp
+
 
 # Adjust sys.path to allow importing from the parent directory (chatbot)
 # This assumes 'app.py' is in 'chatbot/chatbot/web/' and 'core' is in 'chatbot/chatbot/core/'
-# We need to go up two levels from app.py to reach the project root 'chatbot/'
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
@@ -21,6 +25,19 @@ except ImportError as e:
         return f"Chatbot core logic error: Could not import 'get_response'. Details: {e}"
 
 app = Flask(__name__) # Flask will look for templates in a 'templates' folder in the same dir as app.py
+
+# Secret key is crucial for session management, which admin login uses.
+# IMPORTANT: For production, use a fixed, strong, randomly generated secret key stored securely (e.g., env var).
+# Using os.urandom(24) generates a new key each time app restarts, invalidating old sessions. Good for dev, not prod.
+app.secret_key = os.getenv('FLASK_SECRET_KEY', os.urandom(24))
+if app.secret_key == os.urandom(24): # Check if fallback was used
+    print("WARNING: FLASK_SECRET_KEY not set in .env, using a temporary session key. Sessions will not persist across restarts.")
+
+
+# Register Blueprints
+app.register_blueprint(admin_bp) # URLs from admin_bp (like /admin/login) are now active.
+
+# Global or app context variable for conversation history
 conversation = []
 
 @app.route('/', methods=['GET', 'POST'])
@@ -33,23 +50,31 @@ def chat():
         print(f"DEBUG: app.py - Received bot_response: {bot_response}")
         conversation.append({'sender': 'User', 'text': user_message})
         conversation.append({'sender': 'Bot', 'text': bot_response})
-    # Ensure the template is looked for in the correct relative path
     return render_template('index.html', conversation=list(conversation))
 
 if __name__ == '__main__':
-    # This ensures Flask looks for templates in 'chatbot/chatbot/web/templates'
-    # by convention, if the app is in 'chatbot/chatbot/web/'
     print(f"Flask app __name__ is {__name__}")
     print(f"Flask app root_path is {app.root_path}")
     # To ensure dummy template creation works as intended if needed:
-    templates_dir = os.path.join(app.root_path, 'templates')
+    templates_dir = os.path.join(app.root_path, 'templates') # app.root_path is chatbot/chatbot/web
     if not os.path.exists(templates_dir):
         os.makedirs(templates_dir)
         print(f"Created missing templates directory: {templates_dir}")
+        # This dummy index creation might conflict if admin templates are also in a sub-folder here.
+        # The main index.html should be in chatbot/chatbot/web/templates/index.html
+        # Admin templates are in chatbot/chatbot/web/templates/admin/
         dummy_index_path = os.path.join(templates_dir, 'index.html')
-        if not os.path.exists(dummy_index_path):
+        if not os.path.exists(dummy_index_path): # Only create if main index.html is missing
             with open(dummy_index_path, 'w') as f_html:
                 f_html.write("<h1>Fallback Template</h1><p>Dummy index.html created as it was missing.</p>")
                 print(f"Created dummy index.html at {dummy_index_path}")
 
+    # Note: Flask's default template loader looks in a "templates" folder relative to the app's root_path.
+    # The admin blueprint's template_folder='admin' is relative to the app's template folder.
+    # So, admin templates like 'admin/admin_login.html' are sought at '<app_template_dir>/admin/admin_login.html'.
+    # This structure is: chatbot/chatbot/web/templates/admin/admin_login.html, which matches the script.
+
     app.run(debug=True, host='0.0.0.0', port=5000)
+
+# Ensure lines from previous incorrect append are removed if they were there.
+# The overwrite ensures this.

--- a/chatbot/chatbot/web/templates/admin/admin_dashboard.html
+++ b/chatbot/chatbot/web/templates/admin/admin_dashboard.html
@@ -1,0 +1,10 @@
+{% extends "admin/admin_layout.html" %}
+{% block admin_content %}
+    <p>Welcome to the Admin Dashboard!</p>
+    <p>Use the sidebar to navigate and manage your chatbot settings.</p>
+    <p>Current functionalities (placeholders):</p>
+    <ul>
+        <li><a href="{{ url_for('admin.manage_rules') }}">Manage Rules</a></li>
+        <li><a href="{{ url_for('admin.manage_appearance') }}">Manage Appearance</a></li>
+    </ul>
+{% endblock %}

--- a/chatbot/chatbot/web/templates/admin/admin_layout.html
+++ b/chatbot/chatbot/web/templates/admin/admin_layout.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title if title else 'Chatbot Admin' }} - Chatbot Admin</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; background-color: #f4f4f4; }
+        .admin-container { display: flex; min-height: 100vh; }
+        .admin-sidebar { width: 220px; background-color: #333; color: white; padding: 20px; }
+        .admin-sidebar h2 { text-align: center; margin-bottom: 20px; }
+        .admin-sidebar ul { list-style-type: none; padding: 0; }
+        .admin-sidebar ul li a { color: white; text-decoration: none; display: block; padding: 10px 15px; border-radius: 4px; margin-bottom: 5px; }
+        .admin-sidebar ul li a:hover, .admin-sidebar ul li a.active { background-color: #555; }
+        .admin-content { flex-grow: 1; padding: 20px; background-color: #fff; margin: 10px; border-radius: 5px; box-shadow: 0 0 10px rgba(0,0,0,0.1);}
+        .flash-messages { list-style-type: none; padding: 0; margin-bottom: 15px; }
+        .flash-messages li { padding: 10px 15px; margin-bottom: 10px; border-radius: 4px; }
+        .flash-messages li.success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
+        .flash-messages li.danger { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+        .flash-messages li.info { background-color: #d1ecf1; color: #0c5460; border: 1px solid #bee5eb; }
+        .admin-header { margin-bottom: 20px; padding-bottom:10px; border-bottom: 1px solid #eee; }
+        .admin-header h1 { margin:0; }
+    </style>
+</head>
+<body>
+    <div class="admin-container">
+        <aside class="admin-sidebar">
+            <h2>Admin Panel</h2>
+            <nav>
+                <ul>
+                    <li><a href="{{ url_for('admin.dashboard') }}" class="{{ 'active' if request.endpoint == 'admin.dashboard' else '' }}">Dashboard</a></li>
+                    <li><a href="{{ url_for('admin.manage_rules') }}" class="{{ 'active' if request.endpoint == 'admin.manage_rules' else '' }}">Manage Rules</a></li>
+                    <li><a href="{{ url_for('admin.manage_appearance') }}" class="{{ 'active' if request.endpoint == 'admin.manage_appearance' else '' }}">Appearance</a></li>
+                    <li><hr style="border-color: #444;"></li>
+                    <li><a href="{{ url_for('admin.logout') }}">Logout</a></li>
+                </ul>
+            </nav>
+        </aside>
+        <main class="admin-content">
+            <header class="admin-header">
+                <h1>{{ title if title else 'Admin Page' }}</h1>
+            </header>
+            {% with messages = get_flashed_messages(with_categories=true) %}
+                {% if messages %}
+                    <ul class="flash-messages">
+                        {% for category, message in messages %}
+                            <li class="{{ category }}">{{ message }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            {% endwith %}
+            {% block admin_content %}{% endblock %}
+        </main>
+    </div>
+</body>
+</html>

--- a/chatbot/chatbot/web/templates/admin/admin_login.html
+++ b/chatbot/chatbot/web/templates/admin/admin_login.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }} - Chatbot Admin</title>
+    <style>
+        body { font-family: Arial, sans-serif; background-color: #f4f4f4; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; }
+        .login-container { background-color: #fff; padding: 30px; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1); width: 100%; max-width: 400px; }
+        .login-container h1 { text-align: center; margin-bottom: 25px; color: #333; }
+        .form-group { margin-bottom: 20px; }
+        .form-group label { display: block; margin-bottom: 5px; color: #555; }
+        .form-group input[type="text"], .form-group input[type="password"] { width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; }
+        .form-group input[type="submit"] { width: 100%; padding: 10px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
+        .form-group input[type="submit"]:hover { background-color: #0056b3; }
+        .flash-messages { list-style-type: none; padding: 0; margin-bottom: 15px; }
+        .flash-messages li { padding: 10px 15px; margin-bottom: 10px; border-radius: 4px; text-align: center; }
+        .flash-messages li.danger { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <h1>Admin Login</h1>
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                <ul class="flash-messages">
+                    {% for category, message in messages %}
+                        <li class="{{ category }}">{{ message }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        {% endwith %}
+        <form method="POST" action="{{ url_for('admin.login', next=request.args.get('next')) }}">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input type="text" id="username" name="username" required>
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Login">
+            </div>
+        </form>
+    </div>
+</body>
+</html>

--- a/chatbot/chatbot/web/templates/admin/admin_manage_appearance.html
+++ b/chatbot/chatbot/web/templates/admin/admin_manage_appearance.html
@@ -1,0 +1,5 @@
+{% extends "admin/admin_layout.html" %}
+{% block admin_content %}
+    <p>Appearance customization functionality will be implemented here.</p>
+    <p>You will be able to change colors, fonts, and other visual aspects of the chat window.</p>
+{% endblock %}

--- a/chatbot/chatbot/web/templates/admin/admin_manage_rules.html
+++ b/chatbot/chatbot/web/templates/admin/admin_manage_rules.html
@@ -1,0 +1,5 @@
+{% extends "admin/admin_layout.html" %}
+{% block admin_content %}
+    <p>Rule management functionality will be implemented here.</p>
+    <p>You will be able to view, add, and upload rules for the chatbot.</p>
+{% endblock %}


### PR DESCRIPTION
This commit introduces the initial framework for an admin panel:

- Creates `chatbot/chatbot/web/admin_views.py` with a Flask Blueprint for admin routes.
- Implements session-based login/logout functionality for `/admin/login` and `/admin/logout`. Admin credentials (`ADMIN_USERNAME`, `ADMIN_PASSWORD`) are loaded from the .env file.
- Adds a `login_required` decorator to protect admin routes.
- Sets up basic admin routes: `/admin/dashboard`, and placeholders for `/admin/rules` and `/admin/appearance`.
- Creates HTML templates for the admin section:
    - `admin_layout.html` (base layout with sidebar)
    - `admin_login.html` (login form)
    - `admin_dashboard.html` (simple dashboard page)
    - `admin_manage_rules.html` (placeholder)
    - `admin_manage_appearance.html` (placeholder)
- Updates `chatbot/chatbot/web/app.py` to:
    - Set `app.secret_key` (loading from `FLASK_SECRET_KEY` in .env or defaulting to `os.urandom(24)`).
    - Register the `admin_bp` Blueprint.

The admin interface is now accessible and password-protected. Further development will add functionality to the rule and appearance management pages.